### PR TITLE
feat: make GitHub token or PAT optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: true
   github_token:
     description: "Usually <dollar sign>{{ secrets.GITHUB_TOKEN }}"
-    required: true
+    default: ${{ github.token }}
   limit_to_pr_opened:
     description: "Limit this action to PR opened or reopened"
     default: "false"


### PR DESCRIPTION
Pick up GitHub token automatically, but still allow for a manual one or PAT.

---

# Things!
## Excitement!
[Links!](https://google.ca)
`Code!`